### PR TITLE
Implement EPUB parsing workflow and metadata helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# GoEpubReader
+
+## 简介
+GoEpubReader 是一个使用纯 Go 编写的 EPUB 读取工具库，兼容 EPUB2 与 EPUB3 规范。库的设计目标是为电子书阅读与内容分析提供一套稳定的、仅依赖标准库（外加 `x/net/html`）的接口。它目前聚焦于只读场景，未来也可以在此基础上扩展为写入工具。
+
+### 核心特性
+- 📦 解析 EPUB 容器，自动定位 OPF、目录与章节内容。
+- 🧱 统一的 `Book` 结构体封装，提供元数据、目录、章节访问能力。
+- 🔍 支持 Dublin Core 元数据的快捷访问，同时保留自定义 `<meta>` 信息。
+- 📚 兼容 EPUB2 的 NCX 目录与 EPUB3 的导航文档。
+- 🖼️ 章节解析同时提取文本段落与图片引用路径，适合二次加工。
+
+## Introduction
+GoEpubReader is a pure Go toolkit for reading EPUB files (EPUB2 and EPUB3). The project focuses on building a reusable, read-only API surface that can be used in larger systems such as bookshelf services, content analysis pipelines, or document conversion tools. The current version concentrates on reading, while the exposed abstractions allow future write support without breaking changes.
+
+### Highlights
+- 📦 Parse the EPUB container to discover OPF packages, table of contents files, and chapters.
+- 🧱 A single `Book` abstraction providing access to metadata, TOC, and chapter content.
+- 🔍 Convenience helpers for every Dublin Core metadata key with graceful fallbacks when data is missing.
+- 📚 Support for both EPUB2 (NCX) and EPUB3 (navigation documents) TOC formats.
+- 🖼️ Chapter parsing extracts plain text paragraphs and referenced image paths for downstream processing.
+
+## 快速开始 / Quick Start
+```bash
+# 获取依赖
+go mod tidy
+
+# 运行示例工作流（使用 testEpubs 中的样例文件）
+go run ./...
+```
+
+示例程序位于 `main.go`，会读取 `testEpubs/testEpub1.epub` 并展示：
+
+- 元数据（标题、作者、语言、扩展信息等）；
+- 章节数量与首章文本预览；
+- 整体目录结构。
+
+The sample workflow in `main.go` showcases how to:
+
+- Load an EPUB via `epub.ReadBook`.
+- Access Dublin Core metadata through dedicated helpers, e.g. `book.Title()` / `book.Creator()`.
+- Traverse the TOC with `book.FlattenTOC()` and inspect chapter text using `book.ChapterByIndex`.
+
+## API 概览 / API Overview
+```go
+book, err := epub.ReadBook("path/to/book.epub")
+if err != nil {
+        // handle error
+}
+
+// Dublin Core metadata helpers
+if title, err := book.Title(); err == nil {
+        fmt.Println("Title:", title)
+}
+
+// Generic metadata access
+values, err := book.MetadataByKey("language")
+
+// Iterate over the full metadata map (includes <meta> extensions)
+metadata := book.AllMetadata()
+
+// Work with chapters
+fmt.Println("Total chapters:", book.ChapterCount())
+firstChapter, _ := book.ChapterByIndex(0)
+fmt.Println(firstChapter.Text())
+
+// Concatenate the whole book into a single text blob
+fmt.Println(book.AllChaptersText())
+```
+
+### TOC & 节点工具
+- `book.FlattenTOC()` 返回目录的线性视图，便于构建阅读器界面。
+- `TOC.FindByHref(href)` 可根据资源路径反查目录节点。
+- `HtmlNode` / `XmlNode` 新增的 `Attr`、`FindAll` / `FindNodes` 辅助方法方便后续拓展。
+
+## 设计说明 / Design Notes
+- `Book` 作为统一入口，内部保留了 Container、OPF、TOC、章节等结构，方便上层按需使用。
+- 所有读取操作都会尽量保持无副作用，符合“只读工具库”的定位。
+- 扩展接口（如 `Chapter.Clone`、`Metadata.GetAll`）便于未来在不破坏 API 的情况下增加写入或缓存功能。
+
+如需在项目中集成，可将 `epub` 包直接引入并调用 `ReadBook`。库会在解析过程中使用通用的 XML/HTML 处理逻辑，确保在不同 EPUB 实现中都能稳定工作。

--- a/epub/book.go
+++ b/epub/book.go
@@ -1,5 +1,11 @@
 package epub
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
 type Book struct {
 	Container *Container `json:"container,omitempty"`
 	Opf       *Opf       `json:"opf,omitempty"`
@@ -7,14 +13,157 @@ type Book struct {
 	Chapters  []Chapter  `json:"chapters,omitempty"`
 }
 
-// TODO design some Methods fo Book Type if needed
+var (
+	// ErrMetadataUndefined indicates that a requested metadata field is not
+	// present in the document.
+	ErrMetadataUndefined = errors.New("metadata not defined")
+	// ErrChapterNotFound indicates that the requested chapter could not be
+	// located either by ID or by index.
+	ErrChapterNotFound = errors.New("chapter not found")
+)
 
-// TODO for every dublincore metadata key provide a simple interface to return the metadata, if there is no value just tell user it is not defined
+// MetadataValues returns all values for the given Dublin Core metadata key.
+func (b *Book) MetadataValues(key string) ([]string, error) {
+	key = strings.ToLower(strings.TrimSpace(key))
+	if key == "" {
+		return nil, fmt.Errorf("metadata key is empty")
+	}
+	if b == nil || b.Opf == nil || b.Opf.Metadata == nil {
+		return nil, fmt.Errorf("%w: %s", ErrMetadataUndefined, key)
+	}
+	values := b.Opf.Metadata.Get(key)
+	if len(values) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrMetadataUndefined, key)
+	}
+	return values, nil
+}
 
-// TODO design a interface extract metadata by dublincore keys, this interface can reuse the interface by previous ToDO
+// MetadataValue returns the first value for the provided Dublin Core key.
+func (b *Book) MetadataValue(key string) (string, error) {
+	values, err := b.MetadataValues(key)
+	if err != nil {
+		return "", err
+	}
+	return values[0], nil
+}
 
-// TODO extract chapter content by id or order
+func (b *Book) metadataGetter(key string) func() (string, error) {
+	return func() (string, error) {
+		return b.MetadataValue(key)
+	}
+}
 
-// TODO extract all Metadata, also include some extra information beyond dublincore
+// The following helpers expose a method for each Dublin Core metadata field.
+func (b *Book) Title() (string, error)       { return b.metadataGetter("title")() }
+func (b *Book) Creator() (string, error)     { return b.metadataGetter("creator")() }
+func (b *Book) Subject() (string, error)     { return b.metadataGetter("subject")() }
+func (b *Book) Description() (string, error) { return b.metadataGetter("description")() }
+func (b *Book) Publisher() (string, error)   { return b.metadataGetter("publisher")() }
+func (b *Book) Contributor() (string, error) { return b.metadataGetter("contributor")() }
+func (b *Book) Date() (string, error)        { return b.metadataGetter("date")() }
+func (b *Book) Type() (string, error)        { return b.metadataGetter("type")() }
+func (b *Book) Format() (string, error)      { return b.metadataGetter("format")() }
+func (b *Book) Identifier() (string, error)  { return b.metadataGetter("identifier")() }
+func (b *Book) Language() (string, error)    { return b.metadataGetter("language")() }
+func (b *Book) Source() (string, error)      { return b.metadataGetter("source")() }
+func (b *Book) Relation() (string, error)    { return b.metadataGetter("relation")() }
+func (b *Book) Coverage() (string, error)    { return b.metadataGetter("coverage")() }
+func (b *Book) Rights() (string, error)      { return b.metadataGetter("rights")() }
 
-// TODO extract all chapter text content and concat by order
+// MetadataByKey provides direct access to Dublin Core metadata using a dynamic
+// key. It is a convenience wrapper around MetadataValues and should be used by
+// callers that need to iterate over keys.
+func (b *Book) MetadataByKey(key string) ([]string, error) {
+	return b.MetadataValues(key)
+}
+
+// AllMetadata returns all metadata entries, including extension fields defined
+// in the OPF <meta> tags.
+func (b *Book) AllMetadata() map[string][]string {
+	if b == nil || b.Opf == nil || b.Opf.Metadata == nil {
+		return map[string][]string{}
+	}
+	result := b.Opf.Metadata.GetAll()
+	out := make(map[string][]string, len(result))
+	for k, v := range result {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+// ChapterCount returns the number of parsed chapters.
+func (b *Book) ChapterCount() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.Chapters)
+}
+
+// ChapterByID returns the chapter that matches the provided ID.
+func (b *Book) ChapterByID(id string) (*Chapter, error) {
+	if b == nil {
+		return nil, ErrChapterNotFound
+	}
+	for i := range b.Chapters {
+		if b.Chapters[i].ID == id {
+			return &b.Chapters[i], nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %s", ErrChapterNotFound, id)
+}
+
+// ChapterByIndex returns the chapter by its ordinal index (0-based).
+func (b *Book) ChapterByIndex(index int) (*Chapter, error) {
+	if b == nil || index < 0 || index >= len(b.Chapters) {
+		return nil, fmt.Errorf("%w: index %d", ErrChapterNotFound, index)
+	}
+	return &b.Chapters[index], nil
+}
+
+// ChapterTextByID returns the joined text content of the chapter with the
+// provided ID.
+func (b *Book) ChapterTextByID(id string) (string, error) {
+	chapter, err := b.ChapterByID(id)
+	if err != nil {
+		return "", err
+	}
+	return chapter.Text(), nil
+}
+
+// ChapterTextByIndex returns the joined text content of the chapter at the
+// provided index.
+func (b *Book) ChapterTextByIndex(index int) (string, error) {
+	chapter, err := b.ChapterByIndex(index)
+	if err != nil {
+		return "", err
+	}
+	return chapter.Text(), nil
+}
+
+// AllChaptersText concatenates every chapter's text content in reading order.
+func (b *Book) AllChaptersText() string {
+	if b == nil {
+		return ""
+	}
+	var texts []string
+	for i := range b.Chapters {
+		if text := b.Chapters[i].Text(); text != "" {
+			texts = append(texts, text)
+		}
+	}
+	return strings.Join(texts, "\n\n")
+}
+
+// FlattenTOC returns the table of contents entries as a slice, skipping the
+// synthetic root node if present.
+func (b *Book) FlattenTOC() []TOC {
+	if b == nil || b.TOC == nil {
+		return nil
+	}
+	entries := b.TOC.Flatten()
+	if len(entries) == 0 {
+		return nil
+	}
+	// Skip the root node which only exists as a container.
+	return entries[1:]
+}

--- a/epub/container.go
+++ b/epub/container.go
@@ -1,12 +1,50 @@
 package epub
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"strings"
 )
 
 type Container struct {
 	Rootfiles []EmptyXmlNode
+}
+
+// ParseContainer parses the META-INF/container.xml document into a Container
+// structure.
+func ParseContainer(content []byte) (*Container, error) {
+	root, err := ParseXML(bytes.NewReader(content))
+	if err != nil {
+		return nil, fmt.Errorf("parse container: %w", err)
+	}
+
+	rootfiles := root.FindNode("rootfiles")
+	if rootfiles == nil {
+		return nil, fmt.Errorf("container rootfiles not found")
+	}
+
+	container := &Container{}
+	for i := range rootfiles.XmlNodes {
+		child := &rootfiles.XmlNodes[i]
+		if !strings.EqualFold(child.XMLName.Local, "rootfile") {
+			continue
+		}
+		attrs := make(map[string]string)
+		for _, attr := range child.Attrs {
+			attrs[attr.Name.Local] = attr.Value
+		}
+		container.Rootfiles = append(container.Rootfiles, EmptyXmlNode{
+			Name:  child.XMLName.Local,
+			Attrs: attrs,
+		})
+	}
+
+	if len(container.Rootfiles) == 0 {
+		return nil, fmt.Errorf("no rootfile entries in container")
+	}
+
+	return container, nil
 }
 
 func (c *Container) FindOpfFile() (string, error) {

--- a/epub/reader.go
+++ b/epub/reader.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"sort"
 	"strings"
 )
@@ -33,9 +34,101 @@ func init() {
 	sort.Strings(dublinCoreElements)
 }
 
-// TODO provide a function to new a empty Book type
+// NewBook creates an empty book structure that can later be populated by the
+// parser. The slices are initialised to avoid nil handling by callers.
+func NewBook() *Book {
+	return &Book{
+		Chapters: make([]Chapter, 0),
+	}
+}
 
-// TODO provide a ReadBook function to parse a Book from a epub path, which will fill the empty Book type, this function can use other Parse function and all types' Method
+// ReadBook parses the EPUB file located at epubPath and populates a Book
+// structure with metadata, table of contents and chapter information.
+func ReadBook(epubPath string) (*Book, error) {
+	zr, err := zip.OpenReader(epubPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, zr.Close())
+	}()
+
+	book := NewBook()
+
+	files := collectFiles(zr.File)
+
+	containerFile, ok := files["META-INF/container.xml"]
+	if !ok {
+		return nil, fmt.Errorf("container.xml not found")
+	}
+	containerData, err := getContent(containerFile)
+	if err != nil {
+		return nil, fmt.Errorf("read container: %w", err)
+	}
+	container, err := ParseContainer(containerData)
+	if err != nil {
+		return nil, err
+	}
+	book.Container = container
+
+	opfPath, err := container.FindOpfFile()
+	if err != nil {
+		return nil, err
+	}
+	opfPath = path.Clean(opfPath)
+	opfFile, ok := files[opfPath]
+	if !ok {
+		return nil, fmt.Errorf("opf file not found: %s", opfPath)
+	}
+	opfContent, err := getContent(opfFile)
+	if err != nil {
+		return nil, fmt.Errorf("read opf: %w", err)
+	}
+	opf, err := ParseOpf(opfContent)
+	if err != nil {
+		return nil, err
+	}
+	book.Opf = opf
+
+	opfDir := path.Dir(opfPath)
+	if opfDir == "." {
+		opfDir = ""
+	}
+
+	tocType, tocFile := opf.FindTOCFile(opfPath)
+	if tocType != TOCTypeUnknown && tocFile != "" {
+		tocRef := tocFile
+		if opfDir != "" && strings.HasPrefix(tocRef, opfDir+"/") {
+			tocRef = strings.TrimPrefix(tocRef, opfDir+"/")
+		}
+		entries, parseErr := ParseTOC(tocType, tocRef, opfDir, files)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse toc: %w", parseErr)
+		}
+		book.TOC = &TOC{Children: entries}
+	}
+
+	chapterIDs := opf.Spine.ExtractChapterIDs()
+	hrefLookup := opf.Manifest.HrefLookup(opfPath)
+	for _, id := range chapterIDs {
+		href, ok := hrefLookup[id]
+		if !ok {
+			continue
+		}
+		href = path.Clean(href)
+		chapFile, ok := files[href]
+		if !ok {
+			continue
+		}
+		chapter, parseErr := ParseChapter(id, href, chapFile)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse chapter %s: %w", id, parseErr)
+		}
+		book.Chapters = append(book.Chapters, *chapter)
+	}
+
+	return book, nil
+}
 
 // getContent 从 zip.File 读取全部内容 / getContent reads the full content from the zip file entry.
 func getContent(f *zip.File) ([]byte, error) {

--- a/epub/xml.go
+++ b/epub/xml.go
@@ -18,7 +18,48 @@ type EmptyXmlNode struct {
 	Attrs map[string]string
 }
 
-// TODO complement methods for these Node types if needed
+// Attr returns the attribute value for the provided name if it exists.
+func (n EmptyXmlNode) Attr(name string) (string, bool) {
+	if n.Attrs == nil {
+		return "", false
+	}
+	value, ok := n.Attrs[name]
+	return value, ok
+}
+
+// HasAttr reports whether the given attribute is defined on the node.
+func (n EmptyXmlNode) HasAttr(name string) bool {
+	_, ok := n.Attrs[name]
+	return ok
+}
+
+// Attr returns the attribute value for the provided name if it exists.
+func (xn *XmlNode) Attr(name string) (string, bool) {
+	if xn == nil {
+		return "", false
+	}
+	for _, attr := range xn.Attrs {
+		if strings.EqualFold(attr.Name.Local, name) {
+			return attr.Value, true
+		}
+	}
+	return "", false
+}
+
+// FindNodes returns all descendants with the provided local name.
+func (xn *XmlNode) FindNodes(name string) []*XmlNode {
+	if xn == nil {
+		return nil
+	}
+	var result []*XmlNode
+	if strings.EqualFold(xn.XMLName.Local, name) {
+		result = append(result, xn)
+	}
+	for i := range xn.XmlNodes {
+		result = append(result, xn.XmlNodes[i].FindNodes(name)...)
+	}
+	return result
+}
 
 // ParseXML 解析 XML，返回 XmlNode 树 / ParseXML decodes the XML stream into a XmlNode tree.
 func ParseXML(r io.Reader) (*XmlNode, error) {

--- a/main.go
+++ b/main.go
@@ -1,11 +1,76 @@
 package main
 
-// TODO check if this lib meet the requirements of becoming a read-only tool lib, if not  complement some function that i did not mentioned
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"sort"
+	"strings"
 
-// TODO design a example workflow using testEpubs to show all function and interface
+	"epub2/epub"
+)
 
-// TODO write the readme.md that which has chinese and english versions, introduce all functions this lib can do
-
+// This executable showcases a simple read-only workflow using the library.
 func main() {
+	example := filepath.Join("testEpubs", "testEpub1.epub")
 
+	book, err := epub.ReadBook(example)
+	if err != nil {
+		log.Fatalf("read book: %v", err)
+	}
+
+	fmt.Printf("Loaded %s\n", example)
+
+	if title, err := book.Title(); err == nil {
+		fmt.Printf("Title: %s\n", title)
+	} else {
+		fmt.Printf("Title: %v\n", err)
+	}
+
+	if author, err := book.Creator(); err == nil {
+		fmt.Printf("Author: %s\n", author)
+	}
+
+	metadata := book.AllMetadata()
+	fmt.Printf("Language(s): %s\n", strings.Join(metadata["language"], ", "))
+	fmt.Printf("Total chapters: %d\n", book.ChapterCount())
+
+	if first, err := book.ChapterByIndex(0); err == nil {
+		fmt.Printf("First chapter title: %s\n", first.Title)
+		fmt.Printf("Preview: %s\n", preview(first.Text()))
+	}
+
+	fmt.Println("Table of contents:")
+	entries := book.FlattenTOC()
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.Title) == "" {
+			continue
+		}
+		fmt.Printf("  - %s (%s)\n", entry.Title, entry.Href)
+	}
+
+	fmt.Println("Highlighted metadata:")
+	keys := make([]string, 0, len(metadata))
+	for k := range metadata {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if len(metadata[k]) == 0 {
+			continue
+		}
+		fmt.Printf("  %s: %s\n", k, strings.Join(metadata[k], "; "))
+	}
+}
+
+func preview(text string) string {
+	text = strings.ReplaceAll(text, "\n", " ")
+	fields := strings.Fields(text)
+	text = strings.Join(fields, " ")
+	const limit = 160
+	runes := []rune(text)
+	if len(runes) > limit {
+		return string(runes[:limit]) + "..."
+	}
+	return text
 }


### PR DESCRIPTION
## Summary
- add high-level `Book` helpers for Dublin Core metadata, TOC traversal, and chapter access
- implement EPUB container/OPF parsing pipeline with chapter extraction in `ReadBook`
- document the library in a bilingual README and provide an executable sample workflow

## Testing
- go run ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4de5e917c8322960e4a58322ba6d2